### PR TITLE
Fix EAC R/RG decoding on platforms where char is unsigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bcdec
+# etcdec
 Small header-only C library to decompress any ETC/EAC compressed image inspired by incredible stb libaries (<http://nothings.org/stb>)
 
 Written by Sergii *"iOrange"* Kudlai in 2022.

--- a/etcdec.h
+++ b/etcdec.h
@@ -406,9 +406,9 @@ static void etcdec__decompress_eac_block(const void* compressedBlock, void* deco
     unsigned char* decompressed;
     int baseCodeword, multiplier, modifier, idx;
     int i, j, k;
-    const char* modifiersPtr;
+    const signed char* modifiersPtr;
 
-    static char modifierTable[16][8] = {
+    static signed char modifierTable[16][8] = {
             { -3, -6,  -9, -15, 2, 5, 8, 14 },
             { -3, -7, -10, -13, 2, 6, 9, 12 },
             { -2, -5,  -8, -13, 1, 4, 7, 12 },


### PR DESCRIPTION
First of all, thanks for this little library! 

I ran into this when integrating the library into [Magnum](https://github.com/mosra/magnum). It gave very different results on an ARM64 CI and it turned out to be due to an assumption that chars are signed. Using `signed char` instead of `char` seems to fix the problem, and as far as I checked this was the only problematic case. I didn't spot any similar issue in `bcdec` either.

Also made a minor title fix in the README, hopefully it's fine that I included it in the same PR :)

Thanks again!